### PR TITLE
Hotfix in the babelrc file for React not being loaded globally on run…

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,6 @@
                 }
             }
         ],
-        "@babel/preset-typescript",
-        "@babel/preset-react"
+        "next/babel"
     ]
 }


### PR DESCRIPTION
@scott-coates & @jojawhi 

`.babelrc` requires a change `["@babel/preset-react", {"runtime": "automatic"}]` to include React-Import globally, otherwise the `yarn dev` command would through error `React not found`

Removed The babel entries in favor of `next/bable` which includes both entries plus the runtime config.
https://github.com/vercel/next.js/issues/18096#issuecomment-927747280
